### PR TITLE
feat(devcontainer): add configuration for GH Codespaces and VS Code Dev Containers

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,12 @@
+node_modules/
+**/node_modules/
+.next/
+**/.next/
+.pnpm-store/
+**/.pnpm-store/
+out/
+**/out/
+build/
+**/build/
+.turbo/
+**/.turbo/

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -y upgrade \
+  && apt-get -y install --no-install-recommends git nano openssl zsh \
+  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /root/.gnupg /tmp/library-scripts
+
+RUN chsh -s $(which zsh) root \
+  && chsh -s $(which zsh) node
+
+EXPOSE 3000
+EXPOSE 3001
+EXPOSE 8002
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+RUN su node -c "npm install -g pnpm@7.11.0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "ultra",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "ultra",
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "mkdir -p node_modules && sudo chown -R node:node node_modules && pnpm install --frozen-lockfile",
+  "remoteUser": "node",
+  "settings": {},
+  "extensions": [
+    "bradlc.vscode-tailwindcss",
+    "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode"
+  ],
+  "forwardPorts": [3000, 3001, 8002]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "2.1"
+
+services:
+  ultra:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VARIANT: 16-bullseye
+
+    security_opt:
+      - seccomp:unconfined
+
+    environment:
+      - PUID=1000
+      - PGID=1000
+
+    working_dir: /workspace
+
+    volumes:
+      - ..:/workspace:cached
+      - ultra_node_modules:/workspace/node_modules
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"
+
+    user: node
+
+volumes:
+  ultra_node_modules:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 .pnp
 .pnp.js
+.pnpm-store
 
 # testing
 coverage


### PR DESCRIPTION
For `Hacktoberfest`, I have been adding `GitHub Codespaces / VS Code Remote Containers` configuration for OSS projects to make it easier for contributors to the project to get up and running with the correct developer setup. Including the appropriate configuration for a project allows contributors to work entirely within a web browser via GH Codespaces, or inside of fully, and correctly configured containers on their own computer with VS Code Remote Containers (both of these use the same configuration, as GH Codespaces leverages the Remote Containers features under the hood).

For reference, here are some other repositories for whom I've opened PRs to do the same:

- https://github.com/AnilSeervi/inspirational-quotes/pull/19
- https://github.com/Icon-Shelf/icon-shelf/pull/135 (note that this one is a GUI electron app, but it's still possible to containerize it and do development in the cloud on GH Codespaces!)
- https://github.com/developertools-tech/developertools.tech/issues/36