### PR TITLE
Fixed 'remove' command exception

### DIFF
--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -15,10 +15,10 @@ export async function remove(args: string[]) {
 
   // Remove packages from dependencies
   for (const arg of args) {
-    delete pkg.dependencies[arg];
-    delete pkg.devDependencies[arg];
-    delete pkg.peerDependencies[arg];
-    delete pkg.optionalDependencies[arg];
+    delete pkg.dependencies?.[arg];
+    delete pkg.devDependencies?.[arg];
+    delete pkg.peerDependencies?.[arg];
+    delete pkg.optionalDependencies?.[arg];
   }
 
   // Write CWD package.json


### PR DESCRIPTION
Hi! I found a bug in the stable version of Ultra, when using "ultra remove package-name" it throws an exception if not found in peerDependencies.

```
[Ultra] v0.7.0 (83.54ms)
file:///C:/Users/doiska/Documents/Tools/nvm/v16.16.0/node_modules/ultra-pkg/build/commands/remove.js:15
        delete pkg.peerDependencies[arg];
                                    ^

TypeError: Cannot convert undefined or null to object
    at remove (file:///C:/Users/doiska/Documents/Tools/nvm/v16.16.0/node_modules/ultra-pkg/build/commands/remove.js:15:37)
    at commands (file:///C:/Users/doiska/Documents/Tools/nvm/v16.16.0/node_modules/ultra-pkg/build/commands/index.js:107:16)

```