### PR TITLE
fix 🐛: (cli) Don't install optional Peer Dependencies

### DIFF
--- a/packages/cli/src/commands/benchmark.ts
+++ b/packages/cli/src/commands/benchmark.ts
@@ -133,7 +133,7 @@ const tests = [
   {
     name: "PNPM install (no cache / no lockfile)",
     command:
-      "pnpm install --force --cache-dir=cache/cache --store-dir=cache/store --no-strict-peer-dependencies",
+      "pnpm install --force --cache-dir=cache/cache --store-dir=cache/store",
     pre: `npm cache clean -f && pnpm store prune && ${delCommand} node_modules pnpm-lock.yaml ${homeDir}.local/share/pnpm/store/v3 cache/`,
     spinner: ora(chalk.green(`Running "PNPM install (no cache)"...`)).stop(),
     group: 1,
@@ -141,7 +141,7 @@ const tests = [
   {
     name: "PNPM install (with cache / no lockfile)",
     command:
-      "pnpm install --force --cache-dir=cache/cache --store-dir=cache/store --no-strict-peer-dependencies",
+      "pnpm install --force --cache-dir=cache/cache --store-dir=cache/store",
     pre: `${delCommand} node_modules pnpm-lock.yaml`,
     spinner: ora(
       chalk.green(`Running "PNPM install (with cache / no lockfile)"...`)
@@ -151,7 +151,7 @@ const tests = [
   {
     name: "PNPM install (with cache / with lockfile)",
     command:
-      "pnpm install --force --cache-dir=cache/cache --store-dir=cache/store --no-strict-peer-dependencies",
+      "pnpm install --force --cache-dir=cache/cache --store-dir=cache/store",
     pre: `${delCommand} node_modules`,
     spinner: ora(chalk.green(`Running "PNPM install (with cache)"...`)).stop(),
     group: 3,

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -2,6 +2,7 @@ import type { ultra_lock } from "../../types/pkg";
 import chalk from "chalk";
 import ora from "ora";
 import { writeFile, readFile, unlink, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "path";
 import { performance } from "perf_hooks";
 import binLinks from "bin-links";
@@ -71,6 +72,12 @@ export async function install(opts: string[]) {
 
               const cache = path.join(userUltraCache, lock[pkg][version].cache);
 
+              if (existsSync(pathname)) {
+                await rm(pathname, { recursive: true, force: true }).catch(
+                  () => {}
+                );
+              }
+
               hardLinkSync(cache, pathname);
 
               const manifest = readPackage(path.join(pathname, "package.json"));
@@ -120,7 +127,7 @@ export async function install(opts: string[]) {
   await rm(path.join(process.cwd(), "node_modules"), {
     recursive: true,
     force: true,
-  });
+  }).catch(() => {});
 
   const addDeps = await getParamsDeps(opts);
 
@@ -245,38 +252,41 @@ export async function install(opts: string[]) {
     symbol: chalk.green("⚡"),
   });
 
-  const __postinstall = ora(
-    chalk.gray("Running postinstall scripts...")
-  ).start();
-  const __postinstall_start = performance.now();
+  if (__POSTSCRIPTS.length > 0) {
+    const __postinstall = ora(
+      chalk.gray("Running postinstall scripts...")
+    ).start();
+    const __postinstall_start = performance.now();
 
-  await Promise.all(
-    __POSTSCRIPTS.map(async (script) => {
-      __postinstall.text = chalk.gray(`Running ${script.package}...`);
-      try {
-        await executePost(script.script, script.scriptPath);
-      } catch (e) {
-        ora(
-          chalk.red(`Error with ${script.package} postinstall script - ${e}`)
-        ).fail();
-        return;
-      }
-    })
-  );
+    await Promise.all(
+      __POSTSCRIPTS.map(async (script) => {
+        __postinstall.text = chalk.gray(
+          `Running ${chalk.blueBright(script.package)}...`
+        );
+        try {
+          await executePost(script.script, script.scriptPath);
+        } catch (e) {
+          ora(
+            chalk.red(`Error with ${script.package} postinstall script - ${e}`)
+          ).fail();
+          return;
+        }
+      })
+    );
+
+    const __postinstall_end = performance.now();
+    __postinstall.text = chalk.green(
+      `${__POSTSCRIPTS.length} Post Install scripts completed in ${chalk.gray(
+        parseTime(__postinstall_start, __postinstall_end)
+      )}`
+    );
+
+    __postinstall.stopAndPersist({
+      symbol: chalk.green("⚡"),
+    });
+  }
 
   await basePostInstall();
-
-  const __postinstall_end = performance.now();
-
-  __postinstall.text = chalk.green(
-    `${__POSTSCRIPTS.length} Post Install scripts completed in ${chalk.gray(
-      parseTime(__postinstall_start, __postinstall_end)
-    )}`
-  );
-
-  __postinstall.stopAndPersist({
-    symbol: chalk.green("⚡"),
-  });
 
   // If addDeps is not empty, add them to package.json using flag
   if (addDeps.length > 0) {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -50,12 +50,6 @@ export async function run(args: Array<string>) {
   // Extract env variabled at the start of the script VARIABLE=ENV
   const envVariables = getEnvVariables(script);
 
-  ora(
-    chalk.blue(
-      `Running ${args[0]} script with ${envVariables.length} env variables`
-    )
-  ).info();
-
   // Extract the script without the env variables
   const scriptToRun = script.replace(envVariables.join(" "), "");
 

--- a/packages/cli/src/utils/getDeps.ts
+++ b/packages/cli/src/utils/getDeps.ts
@@ -32,13 +32,21 @@ export const getDeps = (
     : [];
 
   const peerDeps = !opts?.peer
-    ? Object.keys(pkg.peerDependencies || {}).map((dep) => {
-        return {
-          name: dep,
-          version: pkg.peerDependencies[dep],
-          parent: undefined,
-        };
-      }) || []
+    ? Object.keys(pkg.peerDependencies || {})
+        .filter((dep) => {
+          // Remove peer dependencies that are optional in pkg.peerDependenciesMeta
+          if (pkg.peerDependenciesMeta) {
+            return !pkg.peerDependenciesMeta[dep]?.optional;
+          }
+        })
+        .map((dep) => {
+          return {
+            name: dep,
+            version: pkg.peerDependencies[dep],
+            parent: undefined,
+          };
+        })
+        .filter((dep) => dep) || []
     : [];
 
   const optDeps = !opts?.opts


### PR DESCRIPTION
Ultra was installing optional Peer Dependencies like `node-sass` that takes a lot of time to run post install scripts.